### PR TITLE
Adds MacOS-arm64 build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
   release-pypi-linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build wheels
       run: |
           docker run --rm -v ${{ github.workspace }}:/src:rw --workdir=/src \
@@ -39,7 +39,7 @@ jobs:
       img: quay.io/pypa/manylinux2014_aarch64:2024-08-03-32dfa47
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Set up QEMU
       id: qemu
       uses: docker/setup-qemu-action@v2
@@ -73,10 +73,10 @@ jobs:
     - uses: fortran-lang/setup-fortran@v1
       with:
         compiler: gcc
-        version: 11
-    - uses: actions/checkout@v3
+        version: 13
+    - uses: actions/checkout@v4
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.14.1
+      uses: pypa/cibuildwheel@v2.21.0
       env:
         CIBW_BUILD: cp311-macosx_x86_64
         CIBW_BUILD_VERBOSITY: "1"
@@ -89,28 +89,25 @@ jobs:
           export TWINE_PASSWORD="${{ secrets.PYPI_API_TOKEN }}"
           twine upload --verbose mac-wheels/*
 
-# GCC is not readily supported on Apple Silicon
-#  release-pypi-macos-arm64:
-#    name: Build wheels for Apple M chips
-#    runs-on: macos-12
-#    steps:
-#    - uses: fortran-lang/setup-fortran@v1
-#      with:
-#        compiler: gcc
-#        version: 11
-#    - uses: actions/checkout@v3
-#    - name: Build wheels
-#      uses: pypa/cibuildwheel@v2.14.1
-#      env:
-#        CIBW_BUILD: cp311-macosx_arm64
-#        CIBW_BUILD_VERBOSITY: "1"
-#        CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-#        CMAKE_OSX_ARCHITECTURES: arm64
-#      with:
-#        output-dir: mac-wheels
-#    - name: Publish to PyPI
-#      run: |
-#          pip3 install twine
-#          export TWINE_USERNAME=__token__
-#          export TWINE_PASSWORD="${{ secrets.PYPI_API_TOKEN }}"
-#          twine upload --verbose mac-wheels/*
+  release-pypi-macos-arm64:
+    name: Build wheels for Apple M chips
+    runs-on: macos-14
+    steps:
+    - uses: fortran-lang/setup-fortran@v1
+      with:
+        compiler: gcc
+        version: 13
+    - uses: actions/checkout@v4
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.21.0
+      env:
+        CIBW_BUILD: cp311-macosx_arm64
+        CIBW_BUILD_VERBOSITY: "1"
+      with:
+        output-dir: mac-wheels
+    - name: Publish to PyPI
+      run: |
+          pip3 install twine==6.0.1
+          export TWINE_USERNAME=__token__
+          export TWINE_PASSWORD="${{ secrets.PYPI_API_TOKEN }}"
+          twine upload --verbose mac-wheels/*


### PR DESCRIPTION
Also updates checkout action and gcc version.

I'm not super familiar with the vagaries of publishing packages, so worth checking that everything is done correctly, but it works fine on my machine. May be useful to package versions providing builds against newer versions of python.